### PR TITLE
Add HTTPS support for ipv6.google.com

### DIFF
--- a/extension/chrome/manifest.json
+++ b/extension/chrome/manifest.json
@@ -14,7 +14,7 @@
                  "http?://www.google.*/search*", "http?://www.google.*/webhp?hl=*",
                  "https://encrypted.google.*/", "https://encrypted.google.*/#hl=*",
                  "https://encrypted.gogole.*/search*", "https://encrypted.google.*/webhp?hl=*",
-                 "http://ipv6.google.com/", "http://ipv6.google.com/search*"
+                 "http?://ipv6.google.com/", "http?://ipv6.google.com/search*"
                   ],
     "run_at": "document_end"
   } ],


### PR DESCRIPTION
Hi, @dangoakachan 

扩展很好用。我发现没有匹配到 https://ipv6.google.com/ ，修改了下。
